### PR TITLE
Tagging tests that should not be used on plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,9 @@
       "email": "noreply@pantheon.io"
     }
   ],
-  "require-dev": {
-    "behat/mink-selenium2-driver": "~1.1",
-    "behat/mink-extension": "~2.0",
-    "symfony/dependency-injection": "2.7.11",
+  "require": {
     "behat/behat": "^3.1",
+    "behat/mink-extension": "^2.2",
     "behat/mink-goutte-driver": "^1.2"
   }
 }

--- a/features/0-install.feature
+++ b/features/0-install.feature
@@ -1,5 +1,6 @@
 Feature: Install WordPress through the web UI
 
+  @upstreamonly
   Scenario: Install WordPress with the en_US locale
     When I go to "/"
     Then print current URL
@@ -29,6 +30,7 @@ Feature: Install WordPress through the web UI
     When I go to "/"
     Then the response should contain "<link rel='stylesheet' id='twentysixteen-style-css'"
 
+  @upstreamonly
   Scenario: Delete Akismet and Hello Dolly
     When I go to "wp-login.php"
     And I fill in "log" with "pantheon"

--- a/features/plugins.feature
+++ b/features/plugins.feature
@@ -8,6 +8,7 @@ Feature: Manage WordPress plugins
     Then print current URL
     And I should be on "/wp-admin/"
 
+  @upstreamonly
   Scenario: Install, activate, deactivate, and delete a plugin
     When I go to "/wp-admin/plugin-install.php?tab=search&s=hello+dolly"
     And I follow "Hello Dolly"


### PR DESCRIPTION
We're using this suite of tests on plugins and need to exclude some scenarios. We can do that by tag.
