### PR TITLE
Custom context for login step and global variables

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -6,6 +6,7 @@ default:
         - features
       contexts:
         - Behat\MinkExtension\Context\MinkContext
+        - AdminLogIn
   extensions:
     Behat\MinkExtension:
       # base_url set by ENV

--- a/behat.yml
+++ b/behat.yml
@@ -6,7 +6,7 @@ default:
         - features
       contexts:
         - Behat\MinkExtension\Context\MinkContext
-        - AdminLogIn
+        - PantheonSystems\PantheonWordPressUpstreamTests\Behat\AdminLogIn
   extensions:
     Behat\MinkExtension:
       # base_url set by ENV

--- a/circle.yml
+++ b/circle.yml
@@ -25,4 +25,4 @@ test:
   override:
     - ./test.sh
   post:
-    # - ./cleanup.sh
+    - ./cleanup.sh

--- a/circle.yml
+++ b/circle.yml
@@ -25,4 +25,4 @@ test:
   override:
     - ./test.sh
   post:
-    - ./cleanup.sh
+    # - ./cleanup.sh

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
   environment:
     TERMINUS_ENV: ci-$CIRCLE_BUILD_NUM
     TERMINUS_SITE: wordpress-upstream
-    WORDPRESS_ADMIN_PASSWORD: openssl rand -hex 8
+    WORDPRESS_ADMIN_PASSWORD: openssl rand -base64 8
 
 dependencies:
   cache_directories:

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
   environment:
     TERMINUS_ENV: ci-$CIRCLE_BUILD_NUM
     TERMINUS_SITE: wordpress-upstream
+    WORDPRESS_ADMIN_USERNAME: openssl rand -hex 8
     WORDPRESS_ADMIN_PASSWORD: openssl rand -base64 8
 
 dependencies:

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
   environment:
     TERMINUS_ENV: ci-$CIRCLE_BUILD_NUM
     TERMINUS_SITE: wordpress-upstream
+    WORDPRESS_ADMIN_PASSWORD: openssl rand -hex 8
 
 dependencies:
   cache_directories:

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,6 @@
     "behat/mink-goutte-driver": "^1.2"
   },
   "autoload": {
-    "psr-0": { "PantheonSystems\\PantheonWordPressUpstreamTests\\Behat": "features/bootstrap/" }
+    "psr-4": { "PantheonSystems\\PantheonWordPressUpstreamTests\\Behat": "features/bootstrap/" }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,6 @@
     "behat/mink-goutte-driver": "^1.2"
   },
   "autoload": {
-    "psr-4": { "PantheonSystems\\PantheonWordPressUpstreamTests\\Behat": "features/bootstrap/" }
+    "psr-4": { "PantheonSystems\\PantheonWordPressUpstreamTests\\Behat\\": "features/bootstrap/" }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,8 @@
     "behat/behat": "^3.1",
     "behat/mink-extension": "^2.2",
     "behat/mink-goutte-driver": "^1.2"
+  },
+  "autoload": {
+    "psr-0": { "PantheonSystems\\PantheonWordPressUpstreamTests\\Behat": "features/bootstrap/" }
   }
 }

--- a/features/0-install.feature
+++ b/features/0-install.feature
@@ -12,7 +12,7 @@ Feature: Install WordPress through the web UI
     And I should see "Welcome to the famous five-minute WordPress installation process!"
 
     When I fill in "weblog_title" with "Pantheon WordPress Upstream"
-    And I fill in "user_name" with "pantheon"
+    And I fill in "user_name" with the command line global variable: "WORDPRESS_ADMIN_USERNAME"
     And I fill in "admin_password" with the command line global variable: "WORDPRESS_ADMIN_PASSWORD"
     And I fill in "admin_password2" with the command line global variable: "WORDPRESS_ADMIN_PASSWORD"
     And I check "pw_weak"

--- a/features/0-install.feature
+++ b/features/0-install.feature
@@ -13,8 +13,8 @@ Feature: Install WordPress through the web UI
 
     When I fill in "weblog_title" with "Pantheon WordPress Upstream"
     And I fill in "user_name" with "pantheon"
-    And I fill in "admin_password" with "pantheon"
-    And I fill in "admin_password2" with "pantheon"
+    And I fill in "admin_password" with the command line global variable: "WORDPRESS_ADMIN_PASSWORD"
+    And I fill in "admin_password2" with the command line global variable: "WORDPRESS_ADMIN_PASSWORD"
     And I check "pw_weak"
     And I fill in "admin_email" with "wordpress-upstream@getpantheon.com"
     And I press "submit"

--- a/features/0-install.feature
+++ b/features/0-install.feature
@@ -32,12 +32,7 @@ Feature: Install WordPress through the web UI
 
   @upstreamonly
   Scenario: Delete Akismet and Hello Dolly
-    When I go to "wp-login.php"
-    And I fill in "log" with "pantheon"
-    And I fill in "pwd" with "pantheon"
-    And I press "wp-submit"
-    Then print current URL
-    And I should be on "/wp-admin/"
+    Given I log in as an admin
 
     When I go to "/wp-admin/plugins.php"
     Then I should see "2 items" in the ".displaying-num" element

--- a/features/bootstrap/AdminLogIn.php
+++ b/features/bootstrap/AdminLogIn.php
@@ -23,7 +23,7 @@ class AdminLogIn implements Context, SnippetAcceptingContext {
     /**
      * @Given I log in as an admin
      */
-    public function ILogInAsAnAdimin()
+    public function ILogInAsAnAdmin()
     {
         $this->minkContext->visit('wp-login.php');
         $this->minkContext->fillField('log', 'pantheon');

--- a/features/bootstrap/AdminLogIn.php
+++ b/features/bootstrap/AdminLogIn.php
@@ -21,8 +21,8 @@ class AdminLogIn implements Context, SnippetAcceptingContext {
     {
         $environment = $scope->getEnvironment();
         $this->minkContext = $environment->getContext('Behat\MinkExtension\Context\MinkContext');
-    }    
-    
+    }
+
     /**
      * @Given I log in as an admin
      */

--- a/features/bootstrap/AdminLogIn.php
+++ b/features/bootstrap/AdminLogIn.php
@@ -21,37 +21,17 @@ class AdminLogIn implements Context, SnippetAcceptingContext {
     {
         $environment = $scope->getEnvironment();
         $this->minkContext = $environment->getContext('Behat\MinkExtension\Context\MinkContext');
-    }
-
+    }    
+    
     /**
      * @Given I log in as an admin
      */
     public function ILogInAsAnAdmin()
     {
-
-        echo ("
-username:
-        ");
-        echo (getenv('WORDPRESS_ADMIN_USERNAME'));
-
-
-        echo ("
-password:
-        ");
-        echo (getenv('WORDPRESS_ADMIN_PASSWORD'));
-        echo ("
-
-
-
-
-
-        ");
         $this->minkContext->visit('wp-login.php');
         $this->minkContext->fillField('log', getenv('WORDPRESS_ADMIN_USERNAME'));
         $this->minkContext->fillField('pwd', getenv('WORDPRESS_ADMIN_PASSWORD'));
         $this->minkContext->pressButton('wp-submit');
-        $this->minkContext->printLastResponse();
-
         $this->minkContext->assertPageAddress("wp-admin/");
     }
 

--- a/features/bootstrap/AdminLogIn.php
+++ b/features/bootstrap/AdminLogIn.php
@@ -1,5 +1,8 @@
 <?php
 
+
+namespace PantheonSystems\PantheonWordPressUpstreamTests\Behat;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\MinkExtension\Context\MinkContext;

--- a/features/bootstrap/AdminLogIn.php
+++ b/features/bootstrap/AdminLogIn.php
@@ -26,7 +26,7 @@ class AdminLogIn implements Context, SnippetAcceptingContext {
     public function ILogInAsAnAdimin()
     {
         $this->minkContext->visit('wp-login.php');
-        $this->minkContext->fillField('log', 'pantheon');
+        $this->minkContext->fillField('log', getenv('WORDPRESS_ADMIN_USERNAME'));
         $this->minkContext->fillField('pwd', getenv('WORDPRESS_ADMIN_PASSWORD'));
         $this->minkContext->pressButton('wp-submit');
         $this->minkContext->assertPageAddress("wp-admin/");

--- a/features/bootstrap/AdminLogIn.php
+++ b/features/bootstrap/AdminLogIn.php
@@ -1,0 +1,34 @@
+<?php
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\MinkExtension\Context\MinkContext;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+
+/**
+ * Define application features from the specific context.
+ */
+class AdminLogIn implements Context, SnippetAcceptingContext {
+
+    /** @var \Behat\MinkExtension\Context\MinkContext */
+    private $minkContext;
+
+    /** @BeforeScenario */
+    public function gatherContexts(BeforeScenarioScope $scope)
+    {
+        $environment = $scope->getEnvironment();
+        $this->minkContext = $environment->getContext('Behat\MinkExtension\Context\MinkContext');
+    }    
+    
+    /**
+     * @Given I log in as an admin
+     */
+    public function ILogInAsAnAdimin()
+    {
+        $this->minkContext->visit('wp-login.php');
+        $this->minkContext->fillField('log', 'pantheon');
+        $this->minkContext->fillField('pwd', 'pantheon');
+        $this->minkContext->pressButton('wp-submit');
+        $this->minkContext->assertPageAddress("wp-admin/");
+    }
+}

--- a/features/bootstrap/AdminLogIn.php
+++ b/features/bootstrap/AdminLogIn.php
@@ -18,17 +18,37 @@ class AdminLogIn implements Context, SnippetAcceptingContext {
     {
         $environment = $scope->getEnvironment();
         $this->minkContext = $environment->getContext('Behat\MinkExtension\Context\MinkContext');
-    }    
-    
+    }
+
     /**
      * @Given I log in as an admin
      */
     public function ILogInAsAnAdmin()
     {
+
+        echo ("
+username:
+        ");
+        echo (getenv('WORDPRESS_ADMIN_USERNAME'));
+
+
+        echo ("
+password:
+        ");
+        echo (getenv('WORDPRESS_ADMIN_PASSWORD'));
+        echo ("
+
+
+
+
+
+        ");
         $this->minkContext->visit('wp-login.php');
         $this->minkContext->fillField('log', getenv('WORDPRESS_ADMIN_USERNAME'));
         $this->minkContext->fillField('pwd', getenv('WORDPRESS_ADMIN_PASSWORD'));
         $this->minkContext->pressButton('wp-submit');
+        $this->minkContext->printLastResponse();
+
         $this->minkContext->assertPageAddress("wp-admin/");
     }
 

--- a/features/bootstrap/AdminLogIn.php
+++ b/features/bootstrap/AdminLogIn.php
@@ -27,8 +27,19 @@ class AdminLogIn implements Context, SnippetAcceptingContext {
     {
         $this->minkContext->visit('wp-login.php');
         $this->minkContext->fillField('log', 'pantheon');
-        $this->minkContext->fillField('pwd', 'pantheon');
+        $this->minkContext->fillField('pwd', getenv('WORDPRESS_ADMIN_PASSWORD'));
         $this->minkContext->pressButton('wp-submit');
         $this->minkContext->assertPageAddress("wp-admin/");
+    }
+
+    /**
+     * Fills in form field with specified id|name|label|value
+     * Example: When I fill in "admin_password2" with the command line global variable: "WORDPRESS_ADMIN_PASSWORD"
+     *
+     * @When I fill in :arg1 with the command line global variable: :arg2
+     */
+    public function fillFieldWithGlobal($field, $value)
+    {
+        $this->minkContext->fillField($field, getenv($value));
     }
 }

--- a/features/comments.feature
+++ b/features/comments.feature
@@ -16,12 +16,7 @@ Feature: Manage WordPress comments
     And I should see "Pantheon logged-out test comment"
 
   Scenario: Leave a comment logged-in
-    Given I am on "wp-login.php"
-    And I fill in "log" with "pantheon"
-    And I fill in "pwd" with "pantheon"
-    And I press "wp-submit"
-    Then print current URL
-    And I should be on "/wp-admin/"
+    Given I log in as an admin
 
     When I go to "/hello-world/"
     Then print current URL
@@ -35,12 +30,7 @@ Feature: Manage WordPress comments
     And I should see "Pantheon logged-in test comment"
 
   Scenario: View comments in the backend
-  	Given I am on "wp-login.php"
-    And I fill in "log" with "pantheon"
-    And I fill in "pwd" with "pantheon"
-    And I press "wp-submit"
-    Then print current URL
-    And I should be on "/wp-admin/"
+    Given I log in as an admin
 
     When I go to "/wp-admin/edit-comments.php"
     Then print current URL

--- a/features/options.feature
+++ b/features/options.feature
@@ -1,12 +1,7 @@
 Feature: Manage WordPress options
 
   Background:
-    Given I am on "wp-login.php"
-    And I fill in "log" with "pantheon"
-    And I fill in "pwd" with "pantheon"
-    And I press "wp-submit"
-    Then print current URL
-    And I should be on "/wp-admin/"
+    Given I log in as an admin
 
   Scenario: Update the site tagline
     When I go to "/"

--- a/features/pantheon.feature
+++ b/features/pantheon.feature
@@ -1,12 +1,7 @@
 Feature: Perform Pantheon-specific actions
 
   Background:
-    Given I am on "wp-login.php"
-    And I fill in "log" with "pantheon"
-    And I fill in "pwd" with "pantheon"
-    And I press "wp-submit"
-    Then print current URL
-    And I should be on "/wp-admin/"
+    Given I log in as an admin
 
   Scenario: Change the cache TTL
     When I go to "/wp-admin/options-general.php?page=pantheon-cache"

--- a/features/plugins.feature
+++ b/features/plugins.feature
@@ -1,12 +1,7 @@
 Feature: Manage WordPress plugins
 
   Background:
-    Given I am on "wp-login.php"
-    And I fill in "log" with "pantheon"
-    And I fill in "pwd" with "pantheon"
-    And I press "wp-submit"
-    Then print current URL
-    And I should be on "/wp-admin/"
+    Given I log in as an admin
 
   @upstreamonly
   Scenario: Install, activate, deactivate, and delete a plugin

--- a/features/posts.feature
+++ b/features/posts.feature
@@ -1,12 +1,7 @@
 Feature: Manage WordPress posts
 
   Background:
-    Given I am on "wp-login.php"
-    And I fill in "log" with "pantheon"
-    And I fill in "pwd" with "pantheon"
-    And I press "wp-submit"
-    Then print current URL
-    And I should be on "/wp-admin/"
+    Given I log in as an admin
 
   Scenario: Create and publish a blog post
     When I go to "/wp-admin/post-new.php"

--- a/features/terms.feature
+++ b/features/terms.feature
@@ -1,12 +1,7 @@
 Feature: Manage WordPress terms
 
   Background:
-    Given I am on "wp-login.php"
-    And I fill in "log" with "pantheon"
-    And I fill in "pwd" with "pantheon"
-    And I press "wp-submit"
-    Then print current URL
-    And I should be on "/wp-admin/"
+    Given I log in as an admin
 
   Scenario: Create a new tag
     When I go to "/wp-admin/edit-tags.php?taxonomy=post_tag"

--- a/features/users.feature
+++ b/features/users.feature
@@ -1,12 +1,7 @@
 Feature: Manage WordPress users
 
   Background:
-    Given I am on "wp-login.php"
-    And I fill in "log" with "pantheon"
-    And I fill in "pwd" with "pantheon"
-    And I press "wp-submit"
-    Then print current URL
-    And I should be on "/wp-admin/"
+   Given I log in as an admin
 
   Scenario: User create, update and delete
     When I go to "/wp-admin/user-new.php"


### PR DESCRIPTION
I'm starting this branch to answer https://github.com/pantheon-systems/pantheon-wordpress-upstream-tests/issues/6#issuecomment-235594620

It does two distinct things
1. Adds a custom step `fillFieldWithGlobal()` that allows for filling fields with global variables. This allows a random password to be set for the WordPress user. I think this is preferable to hardcoding an admin password, even for a throw away site.
2. Create a custom step for logging in as an admin `ILogInAsAnAdmin()`. This change makes the `.feature` files more readable.
