### PR TITLE
[WIP] password fix

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,13 +5,19 @@ machine:
   environment:
     TERMINUS_ENV: ci-$CIRCLE_BUILD_NUM
     TERMINUS_SITE: wordpress-upstream
-    WORDPRESS_ADMIN_USERNAME: openssl rand -hex 8
-    WORDPRESS_ADMIN_PASSWORD: openssl rand -base64 8
+    WORDPRESS_ADMIN_USERNAME: pantheon
+    # A random password is set in the dependencies:pre stage as a text file.
+    # This line reads the same file repeatedly. If the openssl call were used
+    # in this step, it would result in a different password being used in each
+    # line of other steps. Each CircleCI command runs in a separate shell.
+    WORDPRESS_ADMIN_PASSWORD: $(cat ~/WORDPRESS_ADMIN_PASSWORD)
 
 dependencies:
   cache_directories:
     - ~/.composer/cache
   pre:
+    # The environment step uses this file to set a global variable.
+    - echo $(openssl rand -hex 8) > ~/WORDPRESS_ADMIN_PASSWORD
     # Set the PHP timezone so that Behat script does not fail.
     # Using > instead of >> will overwrite the file and disable xdebug.
     # xdebug makes composer slower.


### PR DESCRIPTION
I suspect these lines aren't being handled as I previously thought: https://github.com/pantheon-systems/pantheon-wordpress-upstream-tests/blob/34a917248bb548d23cdcd26cec6dc163602bb6e6/circle.yml#L8

EDIT:

Those lines get interpreted as strings, not commands.

```

terminus wp "user list"
[2016-08-03 20:26:58] [info] Running wp user list on wordpress-upstream-ci-58
    cmd: 'user list'
    site: 'wordpress-upstream'
    env: 'ci-58'
tput: No value for $TERM and no -T specified
+----+-------------+-------------+-------------+-------------+----------------+
| ID | user_login  | display_nam | user_email  | user_regist | roles          |
|    |             | e           |             | ered        |                |
+----+-------------+-------------+-------------+-------------+----------------+
| 1  | openssl ran | openssl ran | wordpress-u | 2016-08-03  | administrator  |
|    | d -hex 8    | d -hex 8    | pstream@get | 20:25:42    |                |
|    |             |             | pantheon.co |             |                |
|    |             |             | m           |             |                |
+----+-------------+-------------+-------------+-------------+----------------+

```
