### PR TITLE
Drop non-native response header checks

### DIFF
--- a/features/bootstrap/ResponseHeader.php
+++ b/features/bootstrap/ResponseHeader.php
@@ -27,24 +27,6 @@ class ResponseHeader extends RawMinkContext {
     }
 
     /**
-     * Checks that the current page response header is set
-     *
-     * @Then /^the response header "(?P<name>(?:[^"]|\\")*)" should exist$/
-     */
-    public function assertResponseHeaderExists($name) {
-        $this->assertSession()->responseHeaderMatches($name,'/^.{1,}$/');
-    }
-
-    /**
-     * Checks that the current page response header is not set
-     *
-     * @Then /^the response header "(?P<name>(?:[^"]|\\")*)" should not exist$/
-     */
-    public function assertResponseHeaderNotExists($name) {
-        $this->assertSession()->responseHeaderMatches($name,'/^.{0}$/');
-    }
-
-    /**
      * Checks, that current page response header contains specified value.
      *
      * @Then /^the response header "(?P<name>(?:[^"]|\\")*)" should contain "(?P<value>(?:[^"]|\\")*)"$/

--- a/features/pantheon-logged-out.feature
+++ b/features/pantheon-logged-out.feature
@@ -2,13 +2,11 @@ Feature: Verify various Pantheon features as a logged-out user
 
   Scenario: Cache-Control should default to TTL=600
     When I go to "/"
-    Then the response header "Cache-Control" should exist
-    And the response header "Pragma" should not exist
     And the response header "Cache-Control" should be "public, max-age=600"
+    And the response header "Pragma" should not contain "no-cache"
 
   Scenario: Cache-Control should have "nocache" for logged-in users
     Given I log in as an admin
 
     When I go to "/"
-    And the response header "Pragma" should exist
     And the response header "Pragma" should contain "no-cache"


### PR DESCRIPTION
Checking these with regex is a bit of a hack. Better to check them
differently