### PR TITLE
Drop the logged-in cache header test

### DIFF
--- a/features/pantheon-logged-out.feature
+++ b/features/pantheon-logged-out.feature
@@ -5,8 +5,3 @@ Feature: Verify various Pantheon features as a logged-out user
     And the response header "Cache-Control" should be "public, max-age=600"
     And the response header "Pragma" should not contain "no-cache"
 
-  Scenario: Cache-Control should have "nocache" for logged-in users
-    Given I log in as an admin
-
-    When I go to "/"
-    And the response header "Pragma" should contain "no-cache"


### PR DESCRIPTION
This is flaky on downstream uses of the test suite, and not entirely
necessary at this time.