### PR TITLE
update Cache Control TTL for new defaults

### DIFF
--- a/features/pantheon-logged-out.feature
+++ b/features/pantheon-logged-out.feature
@@ -1,7 +1,7 @@
 Feature: Verify various Pantheon features as a logged-out user
 
-  Scenario: Cache-Control should default to TTL=600
+  Scenario: Cache-Control should default to TTL=604800
     When I go to "/"
-    And the response header "Cache-Control" should be "public, max-age=600"
+    And the response header "Cache-Control" should be "public, max-age=604800"
     And the response header "Pragma" should not contain "no-cache"
 


### PR DESCRIPTION
This PR updates the default Cache Control TTL for the new defaults shipped in the mu-plugin alongside WP 6.5.3.