### PR TITLE
Use `press` instead of `follow`

### DIFF
--- a/features/plugins.feature
+++ b/features/plugins.feature
@@ -10,7 +10,7 @@ Feature: Manage WordPress plugins
     Then print current URL
     Then I should see "Hello Dolly" in the "#plugin-information-title" element
 
-    When I follow "Install Now"
+    When I press "Install Now"
     Then print current URL
     And I should see "Successfully installed the plugin Hello Dolly"
 


### PR DESCRIPTION
Not sure if this breaks anywhere else, but [wpnext-tests](https://github.com/jazzsequence/wpnext-tests) which uses these Behat tests was failing. Replacing "follow" with "press" seems to resolve.