### PR TITLE
ci: Pin GitHub Actions to commit SHAs (DELENG-235)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set PHP timezone to UTC
         run: echo -e "[Date]\ndate.timezone = UTC" | tee /usr/local/etc/php/php.ini > /dev/null


### PR DESCRIPTION
Automated pinning of GitHub Actions to their commit SHAs.

This improves security by preventing supply chain attacks through compromised action tags.
Each action is pinned to its current commit SHA with a comment showing the original version.

## Related Ticket
https://getpantheon.atlassian.net/browse/DELENG-235

## Need Help?
If you have questions or need help, ask in Slack [#ask-delivery-engineering](https://pantheon.enterprise.slack.com/archives/C09SPT0A65B)