### PR TITLE
ci: Update and pin GitHub Actions to latest versions (DELENG-239)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set PHP timezone to UTC
         run: echo -e "[Date]\ndate.timezone = UTC" | tee /usr/local/etc/php/php.ini > /dev/null


### PR DESCRIPTION
Automated update of GitHub Actions to their latest release versions and pinned to commit SHAs.

This ensures you're using the most recent stable versions while also preventing supply chain attacks.

## Related Ticket
https://getpantheon.atlassian.net/browse/DELENG-239

## Need Help?
If you have questions or need help, ask in Slack [#ask-delivery-engineering](https://pantheon.enterprise.slack.com/archives/C09SPT0A65B)