### PR TITLE
Fix cache clear behat test CSS selector

### DIFF
--- a/features/pantheon.feature
+++ b/features/pantheon.feature
@@ -16,7 +16,7 @@ Feature: Perform Pantheon-specific actions
     When I press "Clear Cache"
     Then print current URL
     And I should be on "/wp-admin/options-general.php?page=pantheon-cache&cache-cleared=true"
-    And I should see "Site cache flushed." in the ".updated" element
+    And I should see "Site cache flushed." in the ".notice-success" element
 
   Scenario: Verify the Pantheon MU plugin is present
     When I go to "/wp-admin/plugins.php?plugin_status=mustuse"


### PR DESCRIPTION
## Summary

The "Clear the site cache" behat scenario checks for the success message in a `.updated` element. The Pantheon MU plugin changed the cache flush notice from `.updated` to `.notice-success` in [pantheon-mu-plugin PR #104](https://github.com/pantheon-systems/pantheon-mu-plugin/pull/104) (SITE-5487, Feb 2026).

This causes the behat test to fail on any repo whose test site has applied the upstream update since then.

## Fix

Update the CSS selector from `.updated` to `.notice-success`.

## Downstream impact

The following repos use this package and will pick up the fix on their next `composer update`:

- pantheon-systems/pantheon-advanced-page-cache
- pantheon-systems/pantheon-hud
- pantheon-systems/solr-power
- pantheon-systems/wp-native-php-sessions
- pantheon-systems/wp-redis
- pantheon-systems/wp-saml-auth
- pantheon-systems/plugin-pipeline-example

Downstream repos do not need to manually update their test sites. The `behat-prepare.sh` script applies upstream updates automatically before each CI run, so the MU plugin update propagates on its own. Repos just need to run `composer update pantheon-systems/pantheon-wordpress-upstream-tests` to pick up this fix in their lock file.