### PR TITLE
Fix cache clear behat test CSS selector

### DIFF
--- a/features/pantheon.feature
+++ b/features/pantheon.feature
@@ -16,7 +16,7 @@ Feature: Perform Pantheon-specific actions
     When I press "Clear Cache"
     Then print current URL
     And I should be on "/wp-admin/options-general.php?page=pantheon-cache&cache-cleared=true"
-    And I should see "Site cache flushed." in the ".updated" element
+    And I should see "Site cache flushed." in the ".notice-success" element
 
   Scenario: Verify the Pantheon MU plugin is present
     When I go to "/wp-admin/plugins.php?plugin_status=mustuse"


### PR DESCRIPTION
## Summary

The recent Pantheon MU plugin update ([pantheon-mu-plugin PR #104](https://github.com/pantheon-systems/pantheon-mu-plugin/pull/104), SITE-5487, Feb 2026) changed the CSS class for admin notices from `.updated` to `.notice-success`. This breaks the "Clear the site cache" behat scenario, which still checks for `.updated`.

This was discovered while validating the CircleCI-to-GitHub-Actions migration PR for pantheon-hud ([pantheon-hud PR #175](https://github.com/pantheon-systems/pantheon-hud/pull/175)), which is blocked on this fix.

## Fix

Update the CSS selector from `.updated` to `.notice-success` in `features/pantheon.feature`.

## Downstream impact

This change will positively impact all downstream repos that use this package for behat tests:

- pantheon-systems/pantheon-advanced-page-cache
- pantheon-systems/pantheon-hud
- pantheon-systems/solr-power
- pantheon-systems/wp-native-php-sessions
- pantheon-systems/wp-redis
- pantheon-systems/wp-saml-auth
- pantheon-systems/plugin-pipeline-example

Repos pick up the fix on their next `composer update`. The `behat-prepare.sh` script applies upstream updates automatically before each CI run, so the MU plugin change propagates on its own — no manual test site updates needed.

---

> **Note on branch protection:** This repo has no branch protection on `master` — no required reviews, no required CI checks, and `enforce_admins` is disabled. PRs can be merged without approval or passing tests.
This was discovered the hard way: PR #80 (same fix as this one) was merged by Claude, then immediately reverted. 
Is the lack of branch protection intentional?

> **Note on test site maintenance:** The `wordpress-upstream` test site had 20 pending upstream updates dating back to June 2024 (WordPress 6.5.4), including the MU plugin update that caused this test failure. Updates have been applied as part of this PR. Is it expected that this test site goes unmaintained for over a year?