### PR TITLE
Add a step to submit a form element directly

### DIFF
--- a/features/bootstrap/AdminLogIn.php
+++ b/features/bootstrap/AdminLogIn.php
@@ -45,4 +45,36 @@ class AdminLogIn implements Context, SnippetAcceptingContext {
     {
         $this->minkContext->fillField($field, getenv($value));
     }
+
+    /**
+     * Submits the form matching a CSS selector, without pressing a button.
+     *
+     * Example: When I submit the ".wrap form" form
+     *
+     * Needed on wp-admin settings pages under the browserkit driver. The
+     * site icon block in wp-admin/options-general.php emits one more
+     * </div> than it opens. The HTML5 parser that DomCrawler now uses
+     * (masterminds/html5) unwinds past the enclosing <form> to balance
+     * that, so the submit button is reparented outside the form and the
+     * driver throws "The selected node does not have a form ancestor".
+     * The goutte driver parsed with libxml, which tolerated the
+     * imbalance, so a plain `I press` worked before the driver swap.
+     *
+     * Note that scoping a button lookup to the form does not help: once
+     * the button is reparented it is no longer a descendant of the form.
+     * Submitting the form element itself does work, and the form still
+     * carries its own fields.
+     *
+     * @When I submit the :element form
+     */
+    public function submitFormElement($element)
+    {
+        $form = $this->minkContext->getSession()->getPage()->find('css', $element);
+
+        if (null === $form) {
+            throw new \Exception(sprintf('Form "%s" not found on the page.', $element));
+        }
+
+        $form->submit();
+    }
 }


### PR DESCRIPTION
## Summary

Adds `When I submit the ":element" form` so downstream suites can submit wp-admin settings forms under the BrowserKit driver.

**Jira:** SITE-5774

## Root cause

Confirmed by dumping the live page from CI, not inferred. WordPress core's site icon block in `wp-admin/options-general.php` emits **six `</div>` for five `<div>`**. DomCrawler now parses with `masterminds/html5`, which follows the HTML5 spec and unwinds past the enclosing `<form>` to balance the surplus closes — reparenting the submit button out of the form.

The driver then walks the button's ancestors, finds no form, and throws `The selected node does not have a form ancestor`.

CI evidence, with a control on a page where the same step works:

| Page | Button ancestor chain | Result |
|---|---|---|
| `profile.php` | `p > form#your-profile > div#profile-page` | press OK |
| `options-general.php` | `p > div#wpbody-content` (no form) | throws |

Both pages resolve **exactly one** node — the correct `input#submit`. The tag-balance scan reports `STRAY CLOSE </div>` inside the site-icon markup and `still-open at button: p`.

Goutte parsed with libxml, which tolerated the imbalance, so `I press "submit"` worked on these pages before the driver swap. **This is a real driver behaviour difference, not a broken test.**

## Why not scope the button lookup

An earlier attempt used `I press "submit" in the ".wrap form" element`. That does **not** work: once the button is reparented it is no longer a descendant of the form, so the scoped lookup finds nothing. Verified against the reparented markup that submitting the form element itself does work, and that the form still carries its own fields (`blogname`).

## Impact

No existing steps change. This only adds a step. Downstream repos (`wp-redis`, `wp-native-php-sessions`) will switch their `options-general.php` submit to it in their own PRs.

## Follow-up

The unbalanced markup is a **WordPress core bug**, reproducible on a stock local install (5 `<div>` / 6 `</div>` in the site-icon preview block). Worth reporting to WordPress separately — this step unblocks the driver migration in the meantime.
